### PR TITLE
Use reggen instead of faker.Regexify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb
 	github.com/magiconair/properties v1.8.4 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb h1:w1g9wNDIE/pHSTmAaUhv4TZQuPBS6GV3mMz5hkgziIU=
+github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb/go.mod h1:5ELEyG+X8f+meRWHuqUOewBOhvHkl7M76pdGEansxW4=
 github.com/magiconair/properties v1.7.4-0.20170902060319-8d7837e64d3c/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/internal/openapi/generator/data/stringGenerator.go
+++ b/internal/openapi/generator/data/stringGenerator.go
@@ -3,10 +3,10 @@ package data
 import (
 	"context"
 	"fmt"
+	"github.com/lucasjones/reggen"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/pkg/errors"
-	"syreclabs.com/go/faker"
 )
 
 type stringGenerator struct {
@@ -31,15 +31,16 @@ func (generator *stringGenerator) GenerateDataBySchema(ctx context.Context, sche
 	var value Data
 	var err error
 
+	maxLength := 0
+	if schema.MaxLength != nil {
+		maxLength = int(*schema.MaxLength)
+	}
+
 	if len(schema.Enum) > 0 {
 		value = generator.getRandomEnumValue(schema.Enum)
 	} else if schema.Pattern != "" {
-		value, err = generator.generateValueByPattern(schema.Pattern)
+		value, err = generator.generateValueByPattern(schema.Pattern, maxLength)
 	} else if formatGenerator, isSupported := generator.formatGenerators[schema.Format]; isSupported {
-		maxLength := 0
-		if schema.MaxLength != nil {
-			maxLength = int(*schema.MaxLength)
-		}
 		value = formatGenerator(int(schema.MinLength), maxLength)
 	} else {
 		value, err = generator.textGenerator.GenerateDataBySchema(ctx, schema)
@@ -52,8 +53,8 @@ func (generator *stringGenerator) getRandomEnumValue(enum []interface{}) string 
 	return fmt.Sprint(enum[generator.random.Intn(len(enum))])
 }
 
-func (generator *stringGenerator) generateValueByPattern(pattern string) (string, error) {
-	value, err := faker.Regexify(pattern)
+func (generator *stringGenerator) generateValueByPattern(pattern string, maxLength int) (string, error) {
+	g, err := reggen.NewGenerator(pattern)
 	if err != nil {
 		return "", errors.WithStack(&ErrGenerationFailed{
 			GeneratorID: "stringGenerator",
@@ -61,6 +62,9 @@ func (generator *stringGenerator) generateValueByPattern(pattern string) (string
 			Previous:    err,
 		})
 	}
-
+	if maxLength <= 0 {
+		maxLength = defaultMaxLength
+	}
+	value := g.Generate(maxLength)
 	return value, nil
 }

--- a/internal/openapi/generator/data/stringGenerator_test.go
+++ b/internal/openapi/generator/data/stringGenerator_test.go
@@ -51,7 +51,7 @@ func TestStringGenerator_GenerateDataBySchema_SchemaWithPattern_RegExpGeneratedV
 	stringGeneratorInstance := &stringGenerator{}
 	schema := &openapi3.Schema{
 		Type:    "string",
-		Pattern: "/ABC/",
+		Pattern: "^ABC$",
 	}
 
 	data, err := stringGeneratorInstance.GenerateDataBySchema(context.Background(), schema)


### PR DESCRIPTION
reggen generates string by regex of a better quality.
Take a regex of IPv4 for example.
 ```
faker.Regexify("^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{N}\\p{L}]+)?$")
```

could produce `"(8\.)))62"`

while

```
reggen.Generate("^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{N}\\p{L}]+)?$", 15)
```

produces `"72.65.44.117"`.