### PR TITLE
Allow resolving of external refs in openapi

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -9,7 +9,7 @@ build:
     tests:
       environment:
         go:
-          version: 'go1.14'
+          version: 'go1.18'
       project_setup:
         override:
           - go mod download

--- a/internal/openapi/loader/SpecificationLoader.go
+++ b/internal/openapi/loader/SpecificationLoader.go
@@ -9,7 +9,7 @@ type SpecificationLoader interface {
 func New() SpecificationLoader {
 	return &processingLoader{
 		&autoLoader{
-			loader: openapi3.NewLoader(),
+			loader: &openapi3.Loader{IsExternalRefsAllowed: true},
 		},
 	}
 }


### PR DESCRIPTION
Given an API whose response schema is hosted externally, i want to be able to mock this API without having to edit the openapi file to move the schema definitions inline.

```
openapi: 3.0.0
info:
  title: my-api
  version: 0.0.0
paths:
  /accounts:
    get:
      responses:
        '200':
          description: Some description value text
          content:
            application/json:
              schema:
                type: array
                items:
                  $ref: 'https://gitlab.com/evolucion-digital/containerp/core-library/-/raw/main/accounting/Schemas.yaml#/components/schemas/Account'
```

Before the change, openapi-mock would throw an error about encountering a disallowed external reference. Now mock responses work as expected, returning mock responses that conform to the schema hosted at the given url.

```
curl "localhost:8080/accounts" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3953    0  3953    0     0   199k      0 --:--:-- --:--:-- --:--:--  386k
[
  {
    "description": "Adipisci ipsa. Et eum ea est error neque. Ipsum et veniam. Consectetur neque laudantium voluptatem est ut quod.",
    "id": "Maxime ut qui iusto ut. Ipsa temporibus tenetur rerum debitis vero. Natus quidem beatae et omnis vel sit. Mollitia quaerat cumque et.",
    "name": "Sint ipsa id porro excepturi. Dignissimos dolores error voluptatum. Et facilis magnam architecto et rem omnis. Voluptatem eligendi inventore error cumque cum consequatur sed esse.",
    "nature": "liability",
    "type": "assets"
  },
  {
    "description": "Blanditiis quisquam dolores culpa a voluptatibus quos. Quis excepturi eveniet ab exercitationem praesentium dicta quos. Explicabo beatae.",
    "id": "Voluptatem unde dolores nesciunt eaque et asperiores. Veritatis voluptatem autem eos. Sint. Quas nobis rerum in corporis reiciendis voluptatem. Ut vitae laborum eaque.",
    "name": "Excepturi et.",
    "nature": "liability",
    "type": "assets"
  },
  {
    "description": "Nulla earum fuga saepe at. Qui aspernatur et et. Inventore et odit possimus quasi ipsum itaque at. Laudantium ea. Sunt officiis non molestiae repellat corporis omnis.",
    "id": "Odio. Adipisci dolore cumque illum. Id qui. Eum aut doloremque facilis.",
    "name": "Totam. Sunt vel.",
    "nature": "liability",
    "type": "liabilities"
  },
  {
    "description": "Porro. Consequatur.",
    "id": "Ut quisquam. Facere eius quo dolorum minus. Amet non rerum cumque. Omnis iure et quia tempore explicabo ab.",
    "name": "Qui soluta asperiores sunt numquam totam fugiat. Earum aperiam est. Fugiat. Quam.",
    "nature": "liability",
    "type": "liabilities"
  },
  {
    "description": "Animi. Dolor. Molestiae veniam. Accusamus ad laboriosam eaque et nihil. Eos vel iusto unde et sunt dicta velit vel. Minus ut laboriosam voluptate eum harum omnis occaecati dolorem.",
    "id": "Quae. Non dolor libero. Praesentium modi consequatur architecto porro est quam accusantium.",
    "name": "Provident soluta cumque. Maxime maiores amet provident nulla nisi quod natus atque. Quis. Neque aspernatur omnis consectetur voluptatibus est nostrum.",
    "nature": "asset",
    "type": "assets"
  },
  {
    "description": "Et quaerat rerum debitis nostrum voluptatem. Voluptatibus saepe sed nesciunt expedita. Ratione quibusdam fugit unde. Deleniti voluptas et consequuntur quibusdam sed quia.",
    "id": "Aspernatur culpa esse id sunt reprehenderit sit magnam nihil. Ab quo ipsum aut accusantium consectetur. Non non aspernatur animi ullam nulla unde ut alias. Vel unde libero architecto ex harum vel.",
    "name": "Voluptatem ut est et architecto nisi repellat. Adipisci sed. Quia reprehenderit eligendi non similique nihil numquam eveniet. Necessitatibus. Animi dolor et repellendus ipsam.",
    "nature": "liability",
    "type": "liabilities"
  },
  {
    "description": "Voluptatem veniam similique omnis quam. Voluptas asperiores deserunt doloremque consequatur non. Voluptas officia amet quo commodi magnam. Et et dolores. Est et in perspiciatis quam.",
    "id": "Nostrum ut deserunt qui eum magnam dignissimos minima. Suscipit eos eaque sequi architecto. Dolorem officiis cumque in perferendis dolorem qui maiores quisquam. Unde et eum fuga. Dolor ut sunt omnis.",
    "name": "Aut eos voluptas nam esse pariatur consequatur aut. Illo animi rerum modi qui voluptas accusamus. Vitae pariatur minus a. Minus eveniet fugit molestias aut nihil. Ducimus.",
    "nature": "liability",
    "type": "liabilities"
  },
  {
    "description": "Inventore et id dignissimos rerum aut odit numquam culpa. Laboriosam saepe consequuntur voluptate illo est ipsum ullam. Tenetur possimus. Laudantium vel ut magni corrupti voluptatibus quis.",
    "id": "Culpa. Ad.",
    "name": "Officiis.",
    "nature": "liability",
    "type": "assets"
  },
  {
    "description": "Et voluptatem facere expedita. Sint illo exercitationem delectus esse beatae.",
    "id": "Impedit sunt ratione tempore. Aut doloremque pariatur voluptatem libero voluptate sed dignissimos. Rem rerum et repellendus enim perferendis dolorem omnis aut. Veniam est optio. Autem qui.",
    "name": "Maiores rem ipsa voluptatem adipisci. Officiis cum illo dolores doloribus perspiciatis.",
    "nature": "asset",
    "type": "assets"
  }
]
```