### PR TITLE
fix docker multi-arch build and push to DockerHub

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -27,16 +27,24 @@ jobs:
         run: echo "BUILD_TIME=$(date)" >> $GITHUB_ENV
       - name: Environment Printer
         uses: managedkaos/print-env@v1.0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository:
-          always_pull: true
-          build_args: APP_VERSION=${{ env.APP_VERSION }}, BUILD_TIME=${{ env.BUILD_TIME }}
+          pull: true
+          build-args: |
+            APP_VERSION=${{ env.APP_VERSION }}
+            BUILD_TIME=${{ env.BUILD_TIME }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Hey 👋 ,
I saw there is a failing build and push of the docker image to DockerHub.
In the recent version 3 of the `docker/build-push-action` the configuration changed a bit.
I updated the workflow to work with latest version and as it is proposed [here](https://github.com/docker/build-push-action#usage).
I couldn't test it but I'm using a similar configuration to build and push my docker multi-arch images to DockerHub.