### PR TITLE
ci: fix docker multi-arch build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # build stage
-FROM golang:alpine AS build-env
+FROM --platform=$BUILDPLATFORM golang:alpine AS build-env
 
 ARG APP_VERSION=""
 ARG BUILD_TIME=""
+ARG TARGETOS TARGETARCH
 
 ADD . /project
 
@@ -16,7 +17,7 @@ RUN set -e \
     && cd /project \
     && go mod download \
     && cd /project/cmd/openapi-mock \
-    && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s -X main.version=${APP_VERSION} -X main.buildTime=${BUILD_TIME}" -o openapi-mock \
+    && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s -X main.version=${APP_VERSION} -X main.buildTime=${BUILD_TIME}" -o openapi-mock \
     && ls -la | grep "openapi-mock"
 
 # final stage


### PR DESCRIPTION
see https://github.com/muonsoft/openapi-mock/pull/80#issuecomment-1331059180. Sets arch/os specific environment variable for go build (`GOOS=$TARGETOS GOARCH=$TARGETARCH`). Build succesfully testet with Docker Desktop on Win 10.